### PR TITLE
Dodanie do Open-API endpointu dla "zamowienia sloikow"

### DIFF
--- a/src/main/resources/contract/openapi.yaml
+++ b/src/main/resources/contract/openapi.yaml
@@ -1,0 +1,69 @@
+openapi: 3.0.3
+info:
+  title: JarFactory API
+  version: 1.0.0
+  description: API for ordering jars from the JarFactory
+
+servers:
+  - url: http://localhost:8080
+
+tags:
+  - name: Orders
+    description: Endpoints related to ordering jars.
+
+paths:
+  /jars/order:
+    post:
+      tags:
+        - Orders
+      summary: Create a new jar order
+      operationId: createJarOrder
+      requestBody:
+        description: Order details for jars
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                deliveryDate:
+                  type: string
+                  format: date
+                  example: "2024-08-01"
+                smallJars:
+                  type: integer
+                  example: 10
+                mediumJars:
+                  type: integer
+                  example: 5
+                largeJars:
+                  type: integer
+                  example: 2
+              required:
+                - deliveryDate
+                - smallJars
+                - mediumJars
+                - largeJars
+      responses:
+        '201':
+          description: Order created successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  orderId:
+                    type: string
+                    example: "123e4567-e89b-12d3-a456-426614174000"
+        '422':
+          description: Business logic error
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  rejectReason:
+                    type: string
+                    example: "zamówienie przekraczajace zdolności produkcyjne"
+        '501':
+          description: Not Implemented


### PR DESCRIPTION
Przygotowano plik openApi w formacie **yaml** posiadający endpoint **POST /jars/order** w ramach JarFactory.

Request posiada pola:

- **deliveryDate**
- **ilość małych słoików**
- **ilość średnich słoików**
- **ilość dużych słoików**

W przypadku utworzenia zlecenia z sukcesem serwis odpowiada **HTTP 201 created** a w body znajduje się **identyfikator zamówienia**.

W przypadku błędu biznesowego odpowiadamy **http XXX,** a w body znajdue się example: 
{rejectReson: “**zamówienie przekraczajace zdolności produkcyjne**“}.

Wywołanie endpointa powinno skutkować zwórceniem **notImplementedException**.