### PR TITLE
usunięcie seterów, dodanie metody updateAllFields w JarOrderEntity

### DIFF
--- a/src/main/java/pl/akademiaspecjalistowit/jarfactory/controller/JarsController.java
+++ b/src/main/java/pl/akademiaspecjalistowit/jarfactory/controller/JarsController.java
@@ -25,7 +25,7 @@ public class JarsController implements ApiApi {
     }
 
     @ResponseStatus(HttpStatus.NO_CONTENT)
-    @PatchMapping("/order/{id}")
+    @PatchMapping("/api/v1/jars/order/{id}")
     public void updateJarOrder(@PathVariable("id") UUID orderId, @RequestBody JsonPatch patch) {
         jarOrderService.updateOrder(orderId, patch);
     }

--- a/src/main/java/pl/akademiaspecjalistowit/jarfactory/entity/JarOrderEntity.java
+++ b/src/main/java/pl/akademiaspecjalistowit/jarfactory/entity/JarOrderEntity.java
@@ -5,6 +5,7 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.DynamicUpdate;
+import pl.akademiaspecjalistowit.jarfactory.model.JarOrderEditDto;
 
 import java.time.LocalDate;
 import java.util.UUID;
@@ -65,35 +66,17 @@ public class JarOrderEntity {
         }
     }
 
-    public void setId(Long id) {
-        this.id = id;
-    }
+    public void updateAllFields(JarOrderEditDto jarOrderEdited) {
+        LocalDate deliveryDate = jarOrderEdited.getDeliveryDate();
+        Integer smallJars = jarOrderEdited.getSmallJars();
+        Integer mediumJars = jarOrderEdited.getMediumJars();
+        Integer largeJars = jarOrderEdited.getLargeJars();
 
-    public void setTechnicalId(UUID technicalId) {
-        this.technicalId = technicalId;
-    }
-
-    public void setDeliveryDate(LocalDate deliveryDate) {
-        validateDeliveryDate(deliveryDate);
+        validateEntryParam(deliveryDate, smallJars, mediumJars, largeJars);
         this.deliveryDate = deliveryDate;
-    }
-
-    public void setSmallJars(Integer smallJars) {
-        validateQuantityJars(smallJars, "Small");
         this.smallJars = smallJars;
-    }
-
-    public void setMediumJars(Integer mediumJars) {
-        validateQuantityJars(mediumJars, "Medium");
         this.mediumJars = mediumJars;
-    }
-
-    public void setLargeJars(Integer largeJars) {
-        validateQuantityJars(largeJars, "Large");
         this.largeJars = largeJars;
-    }
-
-    public void setVersion(Integer version) {
-        this.version = version;
+        this.technicalId = jarOrderEdited.getTechnicalId();
     }
 }

--- a/src/main/java/pl/akademiaspecjalistowit/jarfactory/service/JarOrderServiceImpl.java
+++ b/src/main/java/pl/akademiaspecjalistowit/jarfactory/service/JarOrderServiceImpl.java
@@ -73,11 +73,7 @@ public class JarOrderServiceImpl implements JarOrderService {
     }
 
     private void updateJarOrderEntity(JarOrderEditDto jarOrderEdited, JarOrderEntity entity) throws JarFactoryException {
-        entity.setTechnicalId(jarOrderEdited.getTechnicalId());
-        entity.setDeliveryDate(jarOrderEdited.getDeliveryDate());
-        entity.setSmallJars(jarOrderEdited.getSmallJars());
-        entity.setMediumJars(jarOrderEdited.getMediumJars());
-        entity.setLargeJars(jarOrderEdited.getLargeJars());
+        entity.updateAllFields(jarOrderEdited);
     }
 
     private void checkMaxCapabilities(LocalDate deliveryDate, Integer smallJars, Integer mediumJars, Integer largeJars) throws JarFactoryException {


### PR DESCRIPTION
Kryteria akcpetacji:
JarEntity posiada metodę update która przyjmuje obiekt na podstawie którego ma zostać zaktulalizowana po przejściu validacji

https://trello.com/c/gYdW1SNn/23-pozbycie-si%C4%99-setter%C3%B3w-z-jarentity