### PR TITLE
Grouping tests

### DIFF
--- a/src/main/java/pl/akademiaspecjalistowit/jarfactory/configuration/ObjectMapperConfiguration.java
+++ b/src/main/java/pl/akademiaspecjalistowit/jarfactory/configuration/ObjectMapperConfiguration.java
@@ -1,0 +1,16 @@
+package pl.akademiaspecjalistowit.jarfactory.configuration;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class ObjectMapperConfiguration {
+    @Bean
+    public ObjectMapper objectMapper() {
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule());
+        return objectMapper;
+    }
+}

--- a/src/main/java/pl/akademiaspecjalistowit/jarfactory/configuration/ObjectMapperConfiguration.java
+++ b/src/main/java/pl/akademiaspecjalistowit/jarfactory/configuration/ObjectMapperConfiguration.java
@@ -7,10 +7,10 @@ import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class ObjectMapperConfiguration {
-    @Bean
-    public ObjectMapper objectMapper() {
-        ObjectMapper objectMapper = new ObjectMapper();
-        objectMapper.registerModule(new JavaTimeModule());
-        return objectMapper;
-    }
+//    @Bean
+//    public ObjectMapper objectMapper() {
+//        ObjectMapper objectMapper = new ObjectMapper();
+//        objectMapper.registerModule(new JavaTimeModule());
+//        return objectMapper;
+//    }
 }

--- a/src/main/java/pl/akademiaspecjalistowit/jarfactory/service/JarOrderServiceImpl.java
+++ b/src/main/java/pl/akademiaspecjalistowit/jarfactory/service/JarOrderServiceImpl.java
@@ -31,12 +31,11 @@ public class JarOrderServiceImpl implements JarOrderService {
     private final ObjectMapper objectMapper;
     private final JarMapper jarMapper;
 
-    public JarOrderServiceImpl(JarOrderRepository jarOrderRepository, ApiProperties apiProperties, ObjectMapper objectMapper, JarMapper jarMapper) {
+    public JarOrderServiceImpl(JarOrderRepository jarOrderRepository, ApiProperties apiProperties, JarMapper jarMapper, ObjectMapper objectMapper) {
         this.jarOrderRepository = jarOrderRepository;
         this.apiProperties = apiProperties;
-        this.objectMapper = objectMapper;
         this.jarMapper = jarMapper;
-        objectMapper.registerModule(new JavaTimeModule());
+        this.objectMapper = objectMapper;
     }
 
     @Transactional()

--- a/src/main/java/pl/akademiaspecjalistowit/jarfactory/service/JarOrderServiceImpl.java
+++ b/src/main/java/pl/akademiaspecjalistowit/jarfactory/service/JarOrderServiceImpl.java
@@ -21,7 +21,6 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
-import java.util.jar.JarException;
 import java.util.stream.Collectors;
 
 @Service
@@ -31,11 +30,12 @@ public class JarOrderServiceImpl implements JarOrderService {
     private final ObjectMapper objectMapper;
     private final JarMapper jarMapper;
 
-    public JarOrderServiceImpl(JarOrderRepository jarOrderRepository, ApiProperties apiProperties, JarMapper jarMapper, ObjectMapper objectMapper) {
+    public JarOrderServiceImpl(JarOrderRepository jarOrderRepository, ApiProperties apiProperties, ObjectMapper objectMapper, JarMapper jarMapper) {
         this.jarOrderRepository = jarOrderRepository;
         this.apiProperties = apiProperties;
-        this.jarMapper = jarMapper;
         this.objectMapper = objectMapper;
+        this.jarMapper = jarMapper;
+        objectMapper.registerModule(new JavaTimeModule());
     }
 
     @Transactional()

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -19,7 +19,7 @@ spring:
     change-log: classpath:/db/changelog/db.changelog-master.yaml
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: none
     properties:
       hibernate:
         dialect: org.hibernate.dialect.PostgreSQLDialect

--- a/src/test/java/pl/akademiaspecjalistowit/jarfactory/configuration/EmbeddedPostgresConfiguration.java
+++ b/src/test/java/pl/akademiaspecjalistowit/jarfactory/configuration/EmbeddedPostgresConfiguration.java
@@ -34,8 +34,8 @@ public class EmbeddedPostgresConfiguration {
     }
 
     @Bean
-    public JarOrderService jarOrderService(JarOrderRepository jarOrderRepository, ApiProperties apiProperties) {
-        return new JarOrderServiceImpl(jarOrderRepository, apiProperties, new ObjectMapper(), new JarMapper());
+    public JarOrderService jarOrderService(JarOrderRepository jarOrderRepository, ApiProperties apiProperties, ObjectMapper objectMapper) {
+        return new JarOrderServiceImpl(jarOrderRepository, apiProperties, new JarMapper(), objectMapper);
     }
 
     @Bean

--- a/src/test/java/pl/akademiaspecjalistowit/jarfactory/configuration/EmbeddedPostgresConfiguration.java
+++ b/src/test/java/pl/akademiaspecjalistowit/jarfactory/configuration/EmbeddedPostgresConfiguration.java
@@ -34,13 +34,17 @@ public class EmbeddedPostgresConfiguration {
     }
 
     @Bean
-    public JarOrderService jarOrderService(JarOrderRepository jarOrderRepository, ApiProperties apiProperties, ObjectMapper objectMapper) {
-        return new JarOrderServiceImpl(jarOrderRepository, apiProperties, new JarMapper(), objectMapper);
+    public JarOrderService jarOrderService(JarOrderRepository jarOrderRepository, ApiProperties apiProperties) {
+        return new JarOrderServiceImpl(jarOrderRepository, apiProperties, new ObjectMapper(), new JarMapper());
     }
 
     @Bean
     public ApiProperties apiProperties() {
         return new ApiProperties();
+    }
+    @Bean
+    public ObjectMapper objectMapper() {
+        return new ObjectMapper();
     }
 
     public static class EmbeddedPostgresExtension implements AfterAllCallback {

--- a/src/test/java/pl/akademiaspecjalistowit/jarfactory/entity/JarOrderEntityTest.java
+++ b/src/test/java/pl/akademiaspecjalistowit/jarfactory/entity/JarOrderEntityTest.java
@@ -1,0 +1,41 @@
+package pl.akademiaspecjalistowit.jarfactory.entity;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
+import pl.akademiaspecjalistowit.jarfactory.model.JarOrderRequestDto;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.jar.JarException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+class JarOrderEntityTest {
+    private final LocalDate CORRECT_DATE = LocalDate.of(2024, 9, 29);
+    private final Integer CORRECT_QUANTITY_JARS = 100;
+    private final Integer INCORRECT_QUANTITY_JARS = -100;
+    @Test
+    void should_create_order_with_correct_input_data() {
+        //given&when
+        JarOrderEntity jarOrderEntity = new JarOrderEntity(CORRECT_DATE, CORRECT_QUANTITY_JARS, CORRECT_QUANTITY_JARS, CORRECT_QUANTITY_JARS);
+        //then
+        assertThat(jarOrderEntity.getSmallJars()).isEqualTo(CORRECT_QUANTITY_JARS);
+    }
+
+    @Test
+    void should_throw_exception_with_empty_input_delivery_date() throws JarException {
+        //given&when
+        Executable e = () -> new JarOrderEntity(null, CORRECT_QUANTITY_JARS, CORRECT_QUANTITY_JARS, CORRECT_QUANTITY_JARS);
+        //then
+        assertThrows(IllegalArgumentException.class, e);
+    }
+
+    @Test
+    void should_throw_exception_with_incorrect_input_quantity_any_jars() throws JarException {
+       //given&when
+        Executable e = () -> new JarOrderEntity(CORRECT_DATE, CORRECT_QUANTITY_JARS, INCORRECT_QUANTITY_JARS, CORRECT_QUANTITY_JARS);
+        //then
+        assertThrows(IllegalArgumentException.class, e);
+    }
+}

--- a/src/test/java/pl/akademiaspecjalistowit/jarfactory/service/JarOrderServiceTest.java
+++ b/src/test/java/pl/akademiaspecjalistowit/jarfactory/service/JarOrderServiceTest.java
@@ -45,35 +45,7 @@ class JarOrderServiceTest {
     @Autowired
     private ApiProperties apiProperties;
 
-    @Test
-    void should_create_order_with_correct_input_data() throws JarException {
-        //given
-        //when
-        jarOrderService.addOrder(new JarOrderRequestDto(CORRECT_DATE, CORRECT_QUANTITY_JARS, CORRECT_QUANTITY_JARS, CORRECT_QUANTITY_JARS));
-        List<JarOrderEntity> byDeliveryDate = jarOrderRepository.getByDeliveryDate(CORRECT_DATE);
-        //then
-        assertThat(byDeliveryDate.size()).isEqualTo(1);
-    }
 
-    @Test
-    void should_throw_exception_with_empty_input_delivery_date() throws JarException {
-        //given
-        //when
-        Executable e = () -> jarOrderService.addOrder(new JarOrderRequestDto(null, CORRECT_QUANTITY_JARS, CORRECT_QUANTITY_JARS, CORRECT_QUANTITY_JARS));
-
-        //then
-        assertThrows(IllegalArgumentException.class, e);
-    }
-
-    @Test
-    void should_throw_exception_with_incorrect_input_quantity_any_jars() throws JarException {
-        //given
-        //when
-        Executable e = () -> jarOrderService.addOrder(new JarOrderRequestDto(CORRECT_DATE, CORRECT_QUANTITY_JARS, INCORRECT_QUANTITY_JARS, CORRECT_QUANTITY_JARS));
-
-        //then
-        assertThrows(IllegalArgumentException.class, e);
-    }
 
     @Test
     void should_throw_exception_when_input_quantity_any_jars_exceeds_than_max_capacity() throws JarException {

--- a/src/test/java/pl/akademiaspecjalistowit/jarfactory/service/JarOrderServiceTest.java
+++ b/src/test/java/pl/akademiaspecjalistowit/jarfactory/service/JarOrderServiceTest.java
@@ -44,11 +44,12 @@ class JarOrderServiceTest {
     private JarOrderRepository jarOrderRepository;
     @Autowired
     private ApiProperties apiProperties;
-
+    @Autowired
+    private ObjectMapper objectMapper;
 
 
     @Test
-    void should_throw_exception_when_input_quantity_any_jars_exceeds_than_max_capacity() throws JarException {
+    void should_throw_exception_when_input_quantity_any_jars_exceeds_than_max_capacity() {
         //given
         //when
         Executable e = () -> jarOrderService.addOrder(new JarOrderRequestDto(CORRECT_DATE, apiProperties.getS_jar() + 1, CORRECT_QUANTITY_JARS, CORRECT_QUANTITY_JARS));
@@ -57,7 +58,7 @@ class JarOrderServiceTest {
     }
 
     @Test
-    void should_throw_exception_when_total_quantity_exceeds_max_capacity_for_day() throws JarException {
+    void should_throw_exception_when_total_quantity_exceeds_max_capacity_for_day() {
         //given
         jarOrderService.addOrder(new JarOrderRequestDto(CORRECT_DATE, apiProperties.getS_jar(), CORRECT_QUANTITY_JARS, CORRECT_QUANTITY_JARS));
         //when
@@ -137,7 +138,6 @@ class JarOrderServiceTest {
         String patchString = String.format("[{\"op\": \"replace\", \"path\": \"/smallJars\", \"value\": %d}]", changedSmallJars);
         JsonNode jsonPatchNode = objectMapper.readTree(patchString);
         JsonPatch jsonPatch = JsonPatch.fromJson(jsonPatchNode);
-        System.out.println(jarOrderRepository.findAll().toArray().toString());
 
         //when
         Executable e = () -> jarOrderService.updateOrder(uuidNewOrder, jsonPatch);


### PR DESCRIPTION
W ramach JarFacotry JarOrderService posiada zbyt szczegółowe testy. nalezy rozdzielić testy przebiegu biznesowego (testy wartstwy service) od testów jednostkowcch encji

https://trello.com/c/zBV6TGOe/25-refactor-test%C3%B3w-wydzielenie-test%C3%B3w-encji-do-osobnego-testu-unitowego